### PR TITLE
Allow custom strategies

### DIFF
--- a/javascript-sdk/package.json
+++ b/javascript-sdk/package.json
@@ -34,9 +34,11 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.9",
+    "@types/chai-as-promised": "^7.1.8",
     "@types/mocha": "^10.0.3",
     "@types/string-similarity": "^4.0.1",
-    "ts-node": "^10.9.1",
-    "mocha": "^10.2.0"
+    "chai-as-promised": "^7.1.1",
+    "mocha": "^10.2.0",
+    "ts-node": "^10.9.1"
   }
 }

--- a/javascript-sdk/src/config.ts
+++ b/javascript-sdk/src/config.ts
@@ -1,6 +1,25 @@
+import { TacticName } from "./interface";
+
 export interface ApiConfig {
+  // The API key to use for the Rebuff API.
   apiKey: string;
+  // The URL of the Rebuff API. Defaults to https://playground.rebuff.ai.
   apiUrl?: string;
+}
+
+export interface DetectionTactic {
+  // The name of the tactic.
+  name: TacticName;
+  // The threshold to use for this tactic, between 0 and 1, inclusive. If the score is above this threshold, the tactic
+  // will be considered detected.
+  threshold: number;
+}
+
+export interface DetectionStrategy {
+  // The name of the strategy. This is used to invoke this strategy at detection time.
+  name: string;
+  // The tactics that will be executed as part of this strategy.
+  tactics: DetectionTactic[];
 }
 
 export type VectorDbConfig = {
@@ -20,8 +39,18 @@ export interface SdkConfig {
   vectorDB: VectorDbConfig
   openai: {
     apikey: string;
-    model: string;
+    // Defaults to "gpt-3.5-turbo".
+    model?: string;
   };
+  // The strategies to make available to the caller at detection time. If not specified, the "standard" strategy will
+  // be included, which consists of the following tactics:
+  // - "heuristic", threshold 0.75
+  // - "vector_db", threshold 0.9
+  // - "language_model", threshold 0.9
+  strategies?: DetectionStrategy[];
+  // The strategy to use at detection time when the caller does not specify a strategy. If this property is not
+  // specified, "standard" will be the default strategy.
+  defaultStrategy?: string;
 };
 
 export type RebuffConfig = ApiConfig | SdkConfig;

--- a/javascript-sdk/src/index.ts
+++ b/javascript-sdk/src/index.ts
@@ -2,6 +2,8 @@ export { default as RebuffApi } from "./api";
 export { default as RebuffSdk } from "./sdk";
 export type {
   ApiConfig,
+  DetectionStrategy,
+  DetectionTactic,
   SdkConfig,
   RebuffConfig,
   VectorDbConfig,

--- a/javascript-sdk/src/interface.ts
+++ b/javascript-sdk/src/interface.ts
@@ -10,8 +10,8 @@ export enum TacticName {
 export interface TacticOverride {
   // The name of the tactic to override.
   name: TacticName;
-  // The threshold to use for this tactic. If the score is above this threshold, the tactic will be considered detected.
-  // If not specified, the default threshold for the tactic will be used.
+  // The threshold to use for this tactic, between 0 and 1, inclusive. If the score is above this threshold, the tactic
+  // will be considered detected. If not specified, the default threshold for the tactic will be used.
   threshold?: number;
   // Whether to run this tactic. Defaults to true if not specified.
   run?: boolean;
@@ -22,8 +22,12 @@ export interface DetectRequest {
   userInput: string;
   // The base64-encoded user input. If this is specified, the user input will be ignored.
   userInputBase64?: string;
+  // Which pre-defined strategy to use. A strategy is simply a collection of tactics. If not specified, the default
+  // strategy will be used.
+  strategy?: string;
   // Any tactics to change behavior for. If any tactic is not specified, the default threshold for that tactic will be
-  // used.
+  // used. If a tactic override is included for a tactic that is not a part of the specified stratedy, that tactic
+  // override will be ignored.
   tacticOverrides?: TacticOverride[];
 }
 

--- a/javascript-sdk/src/lib/Strategy.ts
+++ b/javascript-sdk/src/lib/Strategy.ts
@@ -1,6 +1,5 @@
 import Tactic from "../tactics/Tactic";
 
-export default interface Strategy {
-  // The tactics that will be executed as part of this strategy.
-  tactics: Tactic[];
-}
+type Strategy = Tactic[];
+
+export default Strategy;

--- a/javascript-sdk/src/sdk.ts
+++ b/javascript-sdk/src/sdk.ts
@@ -3,6 +3,7 @@ import {
   DetectResponse,
   Rebuff,
   RebuffError,
+  TacticName,
   TacticResult,
 } from "./interface";
 import crypto from "crypto";
@@ -15,6 +16,7 @@ import Strategy from "./lib/Strategy";
 import Heuristic from "./tactics/Heuristic";
 import OpenAI from "./tactics/OpenAI";
 import Vector from "./tactics/Vector";
+import Tactic from "./tactics/Tactic";
 
 function generateCanaryWord(length = 8): string {
   // Generate a secure random hexadecimal canary word
@@ -26,38 +28,67 @@ export default class RebuffSdk implements Rebuff {
   private strategies: Record<string, Strategy>;
   private defaultStrategy: string;
 
-  private constructor(strategies: Record<string, Strategy>, vectorStore: VectorStore) {
-    this.vectorStore = vectorStore;
+  private constructor(strategies: Record<string, Strategy>, defaultStrategy: string, vectorStore: VectorStore) {
     this.strategies = strategies;
-    this.defaultStrategy = "standard";
+    this.defaultStrategy = defaultStrategy;
+    this.vectorStore = vectorStore;
   }
 
   public static async init(config: SdkConfig): Promise<RebuffSdk> {
     const vectorStore = await initVectorStore(config);
+    const strategies = await RebuffSdk.getStrategies(config, vectorStore);
+    const defaultStrategy = config.defaultStrategy || "standard";
+    if (!strategies[defaultStrategy]) {
+      throw new RebuffError(
+        `Default strategy not found: ${defaultStrategy}`
+      );
+    }
+    return new RebuffSdk(strategies, defaultStrategy, vectorStore);
+  }
+
+  private static async getStrategies(config: SdkConfig, vectorStore: VectorStore): Promise<Record<string, Strategy>> {
+    let strategiesConfig = config.strategies ? [...config.strategies] : [];
+    if (strategiesConfig.length === 0) {
+      strategiesConfig.push({
+        name: "standard",
+        tactics: [
+          { name: TacticName.Heuristic, threshold: 0.75 },
+          { name: TacticName.VectorDB, threshold: 0.9 },
+          { name: TacticName.LanguageModel, threshold: 0.9 },
+        ],
+      });
+    }
     const openai = {
       conn: getOpenAIInstance(config.openai.apikey),
       model: config.openai.model || "gpt-3.5-turbo",
     };
-    const heuristicScoreThreshold = 0.75;
-    const vectorScoreThreshold = 0.9;
-    const openaiScoreThreshold = 0.9;
-    const strategies = {
-      // For now, this is the only strategy.
-      "standard": {
-        tactics: [
-          new Heuristic(heuristicScoreThreshold),
-          new Vector(vectorScoreThreshold, vectorStore),
-          new OpenAI(openaiScoreThreshold, openai.model, openai.conn),
-        ]
-      },
-    };
-    return new RebuffSdk(strategies, vectorStore);
+    const strategies: Record<string, Strategy> = {};
+    for (const strategyConfig of strategiesConfig) {
+      if (strategies[strategyConfig.name]) {
+        throw new RebuffError(`Duplicate strategy name: ${strategyConfig.name}`);
+      }
+      let tactics = [] as Tactic[];
+      for (const tacticConfig of strategyConfig.tactics) {
+        if (tacticConfig.name === TacticName.Heuristic) {
+          tactics.push(new Heuristic(tacticConfig.threshold));
+        } else if (tacticConfig.name === TacticName.VectorDB) {
+          tactics.push(new Vector(tacticConfig.threshold, vectorStore));
+        } else if (tacticConfig.name === TacticName.LanguageModel) {
+          tactics.push(new OpenAI(tacticConfig.threshold, openai.model, openai.conn));
+        } else {
+          throw new RebuffError(`Unknown tactic name: ${tacticConfig.name}`);
+        }
+      }
+      strategies[strategyConfig.name] = tactics;
+    }
+    return strategies;
   }
 
   async detectInjection({
     userInput = "",
     userInputBase64 = "",
     tacticOverrides = [],
+    strategy = this.defaultStrategy,
   }: DetectRequest): Promise<DetectResponse> {
     if (userInputBase64) {
       // Create a buffer from the hexadecimal string
@@ -68,10 +99,13 @@ export default class RebuffSdk implements Rebuff {
     if (!userInput) {
       throw new RebuffError("userInput is required");
     }
+    if (!this.strategies[strategy]) {
+      throw new RebuffError(`Strategy not found: ${strategy}`);
+    }
 
     let injectionDetected = false;
     let tacticResults: TacticResult[] = [];
-    for (const tactic of this.strategies[this.defaultStrategy].tactics) {
+    for (const tactic of this.strategies[strategy]) {
       const tacticOverride = tacticOverrides.find(t => t.name === tactic.name);
       if (tacticOverride && tacticOverride.run === false) {
         continue;

--- a/javascript-sdk/tests/index.test.ts
+++ b/javascript-sdk/tests/index.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import { describe } from "mocha";
 import { expect } from "chai";
-import { DetectRequest, DetectResponse, TacticName, TacticResult } from "../src/interface";
+import { DetectRequest, DetectResponse, TacticName } from "../src/interface";
 import RebuffSDK from "../src/sdk";
 import { getEnvironmentVariable } from "./helpers";
 
 // Initialize the Rebuff SDK with a real API token and URL
-const rb = new RebuffSDK({
+const rb = await RebuffSDK.init({
   openai: {
     apikey: getEnvironmentVariable("OPENAI_API_KEY"),
     model: "gpt-3.5-turbo",
@@ -19,7 +19,7 @@ const rb = new RebuffSDK({
     }
   }
 });
-const rb_chroma = new RebuffSDK({
+const rb_chroma = await RebuffSDK.init({
   openai: {
     apikey: getEnvironmentVariable("OPENAI_API_KEY"),
     model: "gpt-3.5-turbo",

--- a/javascript-sdk/tests/index.test.ts
+++ b/javascript-sdk/tests/index.test.ts
@@ -1,9 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import { describe } from "mocha";
-import { expect } from "chai";
-import { DetectRequest, DetectResponse, TacticName } from "../src/interface";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { DetectRequest, DetectResponse, TacticName, TacticResult } from "../src/interface";
 import RebuffSDK from "../src/sdk";
 import { getEnvironmentVariable } from "./helpers";
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
 
 // Initialize the Rebuff SDK with a real API token and URL
 const rb = await RebuffSDK.init({
@@ -441,6 +445,16 @@ describe("Rebuff API tests", function () {
         });
         expect(detectResponse.injectionDetected).to.be.false;
       });
+    });
+  });
+
+  describe("detect_injection_invalid_strategy", () => {
+
+    it("should throw an error", async () => {
+      expect(rb.detectInjection({
+        userInput: benign_inputs[0],
+        strategy: "badStrategy",
+      })).to.be.rejected;
     });
   });
 });

--- a/javascript-sdk/tests/init-sdk.test.ts
+++ b/javascript-sdk/tests/init-sdk.test.ts
@@ -1,0 +1,89 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import { describe } from "mocha";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { DetectRequest, DetectResponse, TacticName } from "../src/interface";
+import RebuffSDK from "../src/sdk";
+import { getEnvironmentVariable } from "./helpers";
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+const sdkConfigBase = {
+  openai: {
+    apikey: getEnvironmentVariable("OPENAI_API_KEY"),
+    model: "gpt-3.5-turbo",
+  },
+  vectorDB: {
+    pinecone: {
+      environment: getEnvironmentVariable("PINECONE_ENVIRONMENT"),
+      apikey: getEnvironmentVariable("PINECONE_API_KEY"),
+      index: getEnvironmentVariable("PINECONE_INDEX_NAME"),
+    }
+  }
+};
+
+// eslint-disable-next-line func-names
+describe("Custom strategies tests", function () {
+
+  describe("No strategy specified, bad defaultStrategy", () => {
+    it("should fail during init", async () => {
+      expect(RebuffSDK.init({
+        ...sdkConfigBase,
+        defaultStrategy: "badStrategy",
+      })).to.be.rejected;
+    });
+  });
+
+  describe("Strategy specified, valid defaultStrategy", () => {
+    it("should run detectInjection successfully", async () => {
+      const rb = await RebuffSDK.init({
+        ...sdkConfigBase,
+        strategies: [{
+          name: "customStrategy",
+          tactics: [{
+            name: TacticName.Heuristic,
+            threshold: 0.5,
+          }],
+        }],
+        defaultStrategy: "customStrategy",
+      });
+      const detectResponse = await rb.detectInjection({
+        userInput: "some query",
+      });
+      expect(detectResponse).to.not.be.undefined;
+      expect(detectResponse.tacticResults).to.have.lengthOf(1);
+      expect(detectResponse.tacticResults[0].name).to.eq(TacticName.Heuristic)
+    });
+  });
+
+  describe("Strategy specified, unspecified defaultStrategy", () => {
+    it("should fail during init", async () => {
+      expect(RebuffSDK.init({
+        ...sdkConfigBase,
+        strategies: [{
+          name: "customStrategy",
+          tactics: [{
+            name: TacticName.Heuristic,
+            threshold: 0.5,
+          }],
+        }],
+      })).to.be.rejected;
+    });
+  });
+
+  describe("Strategy specified, unspecified defaultStrategy", () => {
+    it("should fail during init", () => {
+      expect(RebuffSDK.init({
+        ...sdkConfigBase,
+        strategies: [{
+          name: "customStrategy",
+          tactics: [{
+            name: TacticName.Heuristic,
+            threshold: 0.5,
+          }],
+        }],
+      })).to.be.rejected;
+    });
+  });
+});

--- a/javascript-sdk/tsconfig.json
+++ b/javascript-sdk/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "strict": true,

--- a/javascript-sdk/yarn.lock
+++ b/javascript-sdk/yarn.lock
@@ -69,7 +69,14 @@
   resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
-"@types/chai@^4.3.9":
+"@types/chai-as-promised@^7.1.8":
+  version "7.1.8"
+  resolved "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz"
+  integrity sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*", "@types/chai@^4.3.9":
   version "4.3.9"
   resolved "https://registry.npmjs.org/@types/chai/-/chai-4.3.9.tgz"
   integrity sha512-69TtiDzu0bcmKQv3yg1Zx409/Kd7r0b5F1PfpYJfSHzLGtB53547V4u+9iqKYsTu/O2ai6KTb0TInNpvuQ3qmg==
@@ -252,7 +259,14 @@ camelcase@^6.0.0, camelcase@6:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-chai@^4.3.7:
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
+
+chai@^4.3.7, "chai@>= 2.1.2 < 5":
   version "4.3.10"
   resolved "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz"
   integrity sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==
@@ -278,7 +292,7 @@ charenc@0.0.2:
   resolved "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz"
   integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
 
-check-error@^1.0.3:
+check-error@^1.0.2, check-error@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz"
   integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==


### PR DESCRIPTION
This PR allows users of the SDK to configure which tactics should run be\y default and what thresholds they should have. When initializing the SDK, the user passes in 0 or more strategies and optionally chooses the default strategy. At detection time, the user can choose which strategy to execute; if they don't specify a strategy, the default strategy will be used. For whichever strategy is chosen at detection time, the user can also include tactic overrides to disable or change the threshold for one or more tactics.

Here's an example way this might be used. Suppose we have an AI-powered application that manages email. When generating summaries of an email, the application invokes Rebuff using a "High Confidence" strategy and only rejects an email if the likelihood of prompt injection is close to 1. When automatically responding to an email, which is a more sensitive operation than summarizing, the application invokes Rebuff using a "Medium Confidence" strategy that fails if any Rebuff check has a score above 0.5.

For once, my PR is _not_ a breaking change. :grin: 